### PR TITLE
Fixed problem with object property names

### DIFF
--- a/lib/base.ts
+++ b/lib/base.ts
@@ -372,7 +372,7 @@ export class TranspilerBase {
   exitCodeComment() {
     return this.transpiler.exitCodeComment();
   }
-  maybeWrapInCodeComment(shouldWrap = true, newLine = false, emit: () => void): void {
+  maybeWrapInCodeComment({shouldWrap = true, newLine = false}, emit: () => void): void {
     if (shouldWrap) {
       this.enterCodeComment();
     }

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -96,6 +96,11 @@ export function ident(n: ts.Node): string {
   return null;
 }
 
+export function isValidDartIdentifier(name: ts.StringLiteral) {
+  const validIdentifierRegExp = new RegExp('^[a-zA-Z0-9_]*$');
+  return validIdentifierRegExp.test(name.text);
+}
+
 export function isFunctionTypedefLikeInterface(ifDecl: ts.InterfaceDeclaration): boolean {
   return ifDecl.members && ifDecl.members.length === 1 &&
       ts.isCallSignatureDeclaration(ifDecl.members[0]);
@@ -366,6 +371,18 @@ export class TranspilerBase {
   }
   exitCodeComment() {
     return this.transpiler.exitCodeComment();
+  }
+  maybeWrapInCodeComment(shouldWrap = true, newLine = false, emit: () => void): void {
+    if (shouldWrap) {
+      this.enterCodeComment();
+    }
+    emit();
+    if (shouldWrap) {
+      this.exitCodeComment();
+    }
+    if (newLine) {
+      this.emit('\n');
+    }
   }
 
   enterTypeArguments() {

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -96,9 +96,9 @@ export function ident(n: ts.Node): string {
   return null;
 }
 
-export function isValidDartIdentifier(name: ts.StringLiteral) {
-  const validIdentifierRegExp = new RegExp('^[a-zA-Z0-9_]*$');
-  return validIdentifierRegExp.test(name.text);
+export function isValidDartIdentifier(text: string) {
+  const validIdentifierRegExp = new RegExp('^[^0-9_][a-zA-Z0-9_$]*$');
+  return validIdentifierRegExp.test(text);
 }
 
 export function isFunctionTypedefLikeInterface(ifDecl: ts.InterfaceDeclaration): boolean {

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -781,7 +781,7 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
 
     // TODO(derekx): Properties with names that contain special characters are currently ignored by
     // commenting them out. Determine a way to rename these properties in the future.
-    this.maybeWrapInCodeComment(/* shouldWrap */ !hasValidName, /* newLine */ true, () => {
+    this.maybeWrapInCodeComment({shouldWrap: !hasValidName, newLine: true}, () => {
       this.emit('external');
       if (isStatic) this.emit('static');
       this.visit(decl.type);
@@ -791,7 +791,7 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
     });
 
     if (!base.isReadonly(decl)) {
-      this.maybeWrapInCodeComment(/* shouldWrap */ !hasValidName, /* newLine */ true, () => {
+      this.maybeWrapInCodeComment({shouldWrap: !hasValidName, newLine: true}, () => {
         this.emit('external');
         if (isStatic) this.emit('static');
         this.emit('set');

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -223,8 +223,8 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
     this.visitMergingOverloads(decl.members);
 
     if (isPropertyBag) {
-      const propertiesWithValidNames =
-          properties.filter(p => !ts.isStringLiteral(p.name) || base.isValidDartIdentifier(p.name));
+      const propertiesWithValidNames = properties.filter(
+          p => !ts.isStringLiteral(p.name) || base.isValidDartIdentifier(p.name.text));
       this.emit('external factory');
       this.fc.visitTypeName(name);
       if (propertiesWithValidNames.length) {
@@ -775,7 +775,8 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
    */
   private visitProperty(
       decl: ts.PropertyDeclaration|ts.ParameterDeclaration, isParameter?: boolean) {
-    const hasValidName = !ts.isStringLiteral(decl.name) || base.isValidDartIdentifier(decl.name);
+    const hasValidName =
+        !ts.isStringLiteral(decl.name) || base.isValidDartIdentifier(decl.name.text);
     const isStatic = base.isStatic(decl);
 
     // TODO(derekx): Properties with names that contain special characters are currently ignored by

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -223,16 +223,22 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
     this.visitMergingOverloads(decl.members);
 
     if (isPropertyBag) {
+      const propertiesWithValidNames =
+          properties.filter(p => !ts.isStringLiteral(p.name) || base.isValidDartIdentifier(p.name));
       this.emit('external factory');
       this.fc.visitTypeName(name);
-      this.emitNoSpace('({');
-      for (let i = 0; i < properties.length; i++) {
-        if (i > 0) this.emitNoSpace(',');
-        let p = properties[i];
-        this.visit(p.type);
-        this.visit(p.name);
+      if (propertiesWithValidNames.length) {
+        this.emitNoSpace('({');
+        for (let i = 0; i < propertiesWithValidNames.length; i++) {
+          if (i > 0) this.emitNoSpace(',');
+          let p = propertiesWithValidNames[i];
+          this.visit(p.type);
+          this.visit(p.name);
+        }
+        this.emitNoSpace('});');
+      } else {
+        this.emitNoSpace('();');
       }
-      this.emitNoSpace('});');
     }
   }
 
@@ -769,24 +775,32 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
    */
   private visitProperty(
       decl: ts.PropertyDeclaration|ts.ParameterDeclaration, isParameter?: boolean) {
+    const hasValidName = !ts.isStringLiteral(decl.name) || base.isValidDartIdentifier(decl.name);
     const isStatic = base.isStatic(decl);
-    this.emit('external');
-    if (isStatic) this.emit('static');
-    this.visit(decl.type);
-    this.emit('get');
-    this.visitName(decl.name);
-    this.emitNoSpace(';');
 
-    if (!base.isReadonly(decl)) {
+    // TODO(derekx): Properties with names that contain special characters are currently ignored by
+    // commenting them out. Determine a way to rename these properties in the future.
+    this.maybeWrapInCodeComment(/* shouldWrap */ !hasValidName, /* newLine */ true, () => {
       this.emit('external');
       if (isStatic) this.emit('static');
-      this.emit('set');
-      this.visitName(decl.name);
-      this.emitNoSpace('(');
       this.visit(decl.type);
-      this.emit('v');
-      this.emitNoSpace(')');
+      this.emit('get');
+      this.visitName(decl.name);
       this.emitNoSpace(';');
+    });
+
+    if (!base.isReadonly(decl)) {
+      this.maybeWrapInCodeComment(/* shouldWrap */ !hasValidName, /* newLine */ true, () => {
+        this.emit('external');
+        if (isStatic) this.emit('static');
+        this.emit('set');
+        this.visitName(decl.name);
+        this.emitNoSpace('(');
+        this.visit(decl.type);
+        this.emit('v');
+        this.emitNoSpace(')');
+        this.emitNoSpace(';');
+      });
     }
   }
 

--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -21,7 +21,8 @@ export const DART_RESERVED_NAME_PREFIX = 'JS$';
  */
 export function fixupIdentifierName(text: string): string {
   return (FacadeConverter.DART_RESERVED_WORDS.indexOf(text) !== -1 ||
-          FacadeConverter.DART_OTHER_KEYWORDS.indexOf(text) !== -1 || text.match(/^(\d|_)/)) ?
+          FacadeConverter.DART_OTHER_KEYWORDS.indexOf(text) !== -1 ||
+          !base.isValidDartIdentifier(text)) ?
       DART_RESERVED_NAME_PREFIX + text :
       text;
 }

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -381,7 +381,7 @@ abstract class X {
 }`);
   });
   it('supports interface properties', () => {
-    expectTranslate(`interface X { 'x': string; y; }`).to.equal(`@anonymous
+    expectTranslate('interface X { x: string; y; }').to.equal(`@anonymous
 @JS()
 abstract class X {
   external String get x;
@@ -389,6 +389,13 @@ abstract class X {
   external get y;
   external set y(v);
   external factory X({String x, y});
+}`);
+    expectTranslate(`interface X { '!@#$%^&*': string; }`).to.equal(`@anonymous
+@JS()
+abstract class X {
+  /*external String get !@#$%^&*;*/
+  /*external set !@#$%^&*(String v);*/
+  external factory X();
 }`);
   });
 

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -390,12 +390,36 @@ abstract class X {
   external set y(v);
   external factory X({String x, y});
 }`);
+  });
+
+  it('handles interface properties with names that are invalid in Dart ', () => {
     expectTranslate(`interface X { '!@#$%^&*': string; }`).to.equal(`@anonymous
 @JS()
 abstract class X {
   /*external String get !@#$%^&*;*/
   /*external set !@#$%^&*(String v);*/
   external factory X();
+}`);
+    expectTranslate(`interface X { '5abcde': string; }`).to.equal(`@anonymous
+@JS()
+abstract class X {
+  /*external String get 5abcde;*/
+  /*external set 5abcde(String v);*/
+  external factory X();
+}`);
+    expectTranslate(`interface X { '_wxyz': string; }`).to.equal(`@anonymous
+@JS()
+abstract class X {
+  /*external String get _wxyz;*/
+  /*external set _wxyz(String v);*/
+  external factory X();
+}`);
+    expectTranslate(`interface X { 'foo_34_81$': string; }`).to.equal(`@anonymous
+@JS()
+abstract class X {
+  external String get foo_34_81$;
+  external set foo_34_81$(String v);
+  external factory X({String foo_34_81$});
 }`);
   });
 


### PR DESCRIPTION
The problem was that { 'x': number } was being converted to { num
String/*x*/ }

The problem arose because TypeScript now has two different types of
string literals. LiteralType is now used for types and StringLiteral is
the type of an actual string literal.