### PR TITLE
Prevented skipping nodes during mergeVariablesIntoClasses

### DIFF
--- a/lib/merge.ts
+++ b/lib/merge.ts
@@ -457,8 +457,10 @@ export function normalizeSourceFile(f: ts.SourceFile, fc: FacadeConverter, expli
   function removeFromArray(nodes: ts.NodeArray<ts.Node>, v: ts.Node) {
     for (let i = 0, len = nodes.length; i < len; ++i) {
       if (nodes[i] === v) {
+        const emptyNode = ts.createNode(ts.SyntaxKind.EmptyStatement);
+        base.copyLocation(nodes[i], emptyNode);
         // Small hack to get around NodeArrays being readonly
-        Array.prototype.splice.call(nodes, i, 1);
+        Array.prototype.splice.call(nodes, i, 1, emptyNode);
         break;
       }
     }

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -580,6 +580,31 @@ abstract class XStatic {
 }`);
   });
 
+  it('merges top level variables into classes when they are associated with those classes', () => {
+    expectTranslate(`interface X { a: number; }
+                     interface Y { c: number; }
+
+                     declare var X: {prototype: X, new (): X, b: string};
+                     declare var Y: {prototype: Y, new (): Y, d: string};`)
+        .to.equal(`@JS("X")
+abstract class X {
+  external num get a;
+  external set a(num v);
+  external factory X();
+  external static String get b;
+  external static set b(String v);
+}
+
+@JS("Y")
+abstract class Y {
+  external num get c;
+  external set c(num v);
+  external factory Y();
+  external static String get d;
+  external static set d(String v);
+}`);
+  });
+
   // If the lib.dom.d.ts file is compiled, it creates conflicting interface definitions which causes
   // a problem for variable declarations that we have merged into classes. The main problem was that
   // when the declaration transpiler performed the notSimpleBagOfProperties check, it was checking


### PR DESCRIPTION
Nodes were being removed from the source file as the source file was
being traversed, which was causing problems in some cases. Nodes are now
replaced by EmptyStatements rather than being removed.