### PR TITLE
Improved handling of invalid identifiers

### DIFF
--- a/lib/base.ts
+++ b/lib/base.ts
@@ -87,19 +87,16 @@ export interface ExtendedInterfaceDeclaration extends ts.InterfaceDeclaration {
 }
 
 export function ident(n: ts.Node): string {
-  if (!n) return null;
-  if (ts.isIdentifier(n)) return n.text;
-  if (n.kind === ts.SyntaxKind.FirstLiteralToken) return (n as ts.LiteralLikeNode).text;
+  if (ts.isIdentifier(n) || ts.isStringLiteralLike(n)) {
+    return n.text;
+  }
   if (ts.isQualifiedName(n)) {
-    let leftName = ident(n.left);
-    if (leftName) return leftName + '.' + ident(n.right);
+    const leftName = ident(n.left);
+    if (leftName) {
+      return leftName + '.' + ident(n.right);
+    }
   }
   return null;
-}
-
-export function isValidDartIdentifier(text: string) {
-  const validIdentifierRegExp = new RegExp('^[^0-9_][a-zA-Z0-9_$]*$');
-  return validIdentifierRegExp.test(text);
 }
 
 export function isFunctionTypedefLikeInterface(ifDecl: ts.InterfaceDeclaration): boolean {

--- a/lib/merge.ts
+++ b/lib/merge.ts
@@ -429,7 +429,7 @@ export function normalizeSourceFile(f: ts.SourceFile, fc: FacadeConverter, expli
       undefined {
     const members = classLike.members as ts.NodeArray<ts.ClassElement>;
     return members.find((member: ts.ClassElement) => {
-      if (base.ident(member.name) === propName) {
+      if (member.name && base.ident(member.name) === propName) {
         return true;
       }
     });

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -145,7 +145,7 @@ export default class ModuleTranspiler extends base.TranspilerBase {
     return parts.filter((p) => p.length > 0 && p !== '..')
         .map((p) => p.replace(/[^\w.]/g, '_'))
         .map((p) => p.replace(/\.dart$/, ''))
-        .map((p) => FacadeConverter.DART_RESERVED_WORDS.indexOf(p) !== -1 ? '_' + p : p)
+        .map((p) => FacadeConverter.DART_RESERVED_WORDS.has(p) ? '_' + p : p)
         .filter((p) => p.length > 0)
         .join('.');
   }

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -47,8 +47,8 @@ export default class TypeTranspiler extends base.TranspilerBase {
       this.visit(first.left);
       this.emit('.');
       this.visit(first.right);
-    } else if (ts.isIdentifier(node) || node.kind === ts.SyntaxKind.FirstLiteralToken) {
-      let text = fixupIdentifierName(base.ident(node));
+    } else if (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) {
+      const text = fixupIdentifierName(node);
       this.emit(text);
     } else {
       return false;

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -732,15 +732,15 @@ abstract class X {
     expectTranslate(`interface X { '5abcde': string; }`).to.equal(`@anonymous
 @JS()
 abstract class X {
-  /*external String get 5abcde;*/
-  /*external set 5abcde(String v);*/
+  external String get JS$5abcde;
+  external set JS$5abcde(String v);
   external factory X();
 }`);
     expectTranslate(`interface X { '_wxyz': string; }`).to.equal(`@anonymous
 @JS()
 abstract class X {
-  /*external String get _wxyz;*/
-  /*external set _wxyz(String v);*/
+  external String get JS$_wxyz;
+  external set JS$_wxyz(String v);
   external factory X();
 }`);
     expectTranslate(`interface X { 'foo_34_81$': string; }`).to.equal(`@anonymous

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -193,6 +193,65 @@ external set x(X v);`);
   });
 
   describe('special identifiers', () => {
+    // For the Dart keyword list see
+    // https://dart.dev/guides/language/language-tour#keywords
+    it('always renames identifiers that are reserved keywords in Dart', () => {
+      expectTranslate(`declare var rethrow: number;`).to.equal(`@JS()
+external num get JS$rethrow;
+@JS()
+external set JS$rethrow(num v);`);
+
+      expectTranslate(`class X { while: string; }`).to.equal(`@JS()
+class X {
+  // @Ignore
+  X.fakeConstructor$();
+  external String get JS$while;
+  external set JS$while(String v);
+}`);
+    });
+
+    it('only renames built-in keywords when they are used as class or type names', () => {
+      expectTranslate(`declare var abstract: number;`).to.equal(`@JS()
+external num get abstract;
+@JS()
+external set abstract(num v);`);
+
+      expectTranslate(`declare function get(): void;`).to.equal(`@JS()
+external void get();`);
+
+      expectTranslate(`interface X { abstract: string; }`).to.equal(`@anonymous
+@JS()
+abstract class X {
+  external String get abstract;
+  external set abstract(String v);
+  external factory X({String abstract});
+}`);
+
+      expectTranslate(`interface X { get: number; }`).to.equal(`@anonymous
+@JS()
+abstract class X {
+  external num get get;
+  external set get(num v);
+  external factory X({num get});
+}`);
+
+      expectTranslate(`interface abstract { a: number; }`).to.equal(`@anonymous
+@JS()
+abstract class JS$abstract {
+  external num get a;
+  external set a(num v);
+  external factory JS$abstract({num a});
+}`);
+
+      expectTranslate(`class covariant { x: boolean; }`).to.equal(`@JS()
+class JS$covariant {
+  // @Ignore
+  JS$covariant.fakeConstructor$();
+  external bool get x;
+  external set x(bool v);
+}`);
+    });
+
     it('preserves names that begin with two underscores', () => {
       expectWithTypes(`export function f(__a: number): boolean;
 export function f(__a: string): boolean;`)


### PR DESCRIPTION
JS$ is now only emitted when a Dart reserved keyword is used as an identifier or a built-in identifier is used as a class or type name. In the future, we should rename invalid identifiers in another fashion that uses extension methods because JS$ isn't supported by DDC (#63).