### PR TITLE
Switched back to the old behavior of upgrading variables that expose …

### DIFF
--- a/lib/base.ts
+++ b/lib/base.ts
@@ -78,11 +78,11 @@ export type ClassLike = ts.ClassLikeDeclaration|ts.InterfaceDeclaration;
  */
 export interface ExtendedInterfaceDeclaration extends ts.InterfaceDeclaration {
   /**
-   * VariableDeclaration associated with this interface that we want to treat as the concrete
-   * location of this interface to enable interfaces that act like constructors.
-   * Because Dart does not permit calling objects like constructors we have to add this workaround.
+   * The type associated with this interface that we want to treat as the concrete location of this
+   * interface to enable interfaces that act like constructors. Because Dart does not permit calling
+   * objects like constructors we have to add this workaround.
    */
-  classLikeVariableDeclaration?: ts.VariableDeclaration;
+  constructedType?: ts.InterfaceDeclaration|ts.TypeLiteralNode;
 }
 
 export function ident(n: ts.Node): string {

--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -611,9 +611,10 @@ export class FacadeConverter extends base.TranspilerBase {
   }
 
   replaceNode(original: ts.Node, replacement: ts.Node) {
-    if (ts.isVariableDeclaration(original) && ts.isClassDeclaration(replacement)) {
+    if (ts.isVariableDeclaration(original) &&
+        (ts.isInterfaceDeclaration(replacement) || ts.isClassDeclaration(replacement))) {
       // Handle the speical case in mergeVariablesIntoClasses where we upgrade variable declarations
-      // to classes.
+      // to interfaces or classes.
       const symbol = this.tc.getSymbolAtLocation(original.name);
       symbol.declarations = symbol.getDeclarations().map((declaration: ts.Declaration) => {
         // TODO(derekx): Changing the declarations of a symbol like this is a hack. It would be

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -777,9 +777,7 @@ abstract class XType {
 }
 
 @JS()
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external num get b;
@@ -812,9 +810,7 @@ abstract class XType {
 }
 
 @JS()
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external static num get b;
@@ -831,9 +827,7 @@ declare var C: {new(): C; CHECKING: number; }`)
           .to.equal(`import "dart:html" show Event;
 
 @JS()
-class C {
-  // @Ignore
-  C.fakeConstructor$();
+abstract class C {
   external dynamic Function(Event) get oncached;
   external set oncached(dynamic Function(Event) v);
   external factory C();
@@ -854,9 +848,7 @@ declare var X: {
   prototype: X,
   new(a: string, b: number): X
 };`).to.equal(`@JS()
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external num get b;
@@ -877,9 +869,7 @@ declare var X: {
   prototype: X,
   new(a: string, b: number): X
 };`).to.equal(`@JS()
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external static num get b;
@@ -895,9 +885,7 @@ interface Y { c: number; }
 declare var X: {prototype: X, new (): X, b: string};
 declare var Y: {prototype: Y, new (): Y, d: string};
 `).to.equal(`@JS()
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external num get a;
   external set a(num v);
   external factory X();
@@ -906,9 +894,7 @@ class X {
 }
 
 @JS()
-class Y {
-  // @Ignore
-  Y.fakeConstructor$();
+abstract class Y {
   external num get c;
   external set c(num v);
   external factory Y();
@@ -950,9 +936,7 @@ abstract class Y {
 }
 
 @JS()
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external num get b;
@@ -987,9 +971,7 @@ abstract class XType {
 
 // Module m1
 @JS("m1.X")
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external num get b;
@@ -1027,9 +1009,7 @@ abstract class XType {
 }
 
 @JS()
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external num get b;
@@ -1064,9 +1044,7 @@ abstract class XType {
 }
 
 @JS()
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external static num get b;
@@ -1109,9 +1087,7 @@ abstract class X {
 }
 
 @JS()
-class Y {
-  // @Ignore
-  Y.fakeConstructor$();
+abstract class Y {
   external String get a;
   external set a(String v);
   external num get b;
@@ -1146,9 +1122,7 @@ abstract class XType {
 
 // Module m1
 @JS("m1.X")
-class X {
-  // @Ignore
-  X.fakeConstructor$();
+abstract class X {
   external String get a;
   external set a(String v);
   external num get b;
@@ -1224,9 +1198,7 @@ describe('flags', () => {
             }`,
         generateHTMLOpts)
         .to.equal(`@JS()
-class AbstractRange {
-  // @Ignore
-  AbstractRange.fakeConstructor$();
+abstract class AbstractRange {
   external bool get collapsed;
   external num get endOffset;
   external num get startOffset;
@@ -1260,9 +1232,7 @@ abstract class CacheBase {
 }
 
 @JS()
-class MyCache implements CacheBase {
-  // @Ignore
-  MyCache.fakeConstructor$();
+abstract class MyCache implements CacheBase {
   external factory MyCache();
   external static num get CHECKING;
   external static num get DOWNLOADING;
@@ -1300,9 +1270,7 @@ abstract class CacheBase {
 }
 
 @JS()
-class MyCache implements CacheBase {
-  // @Ignore
-  MyCache.fakeConstructor$();
+abstract class MyCache implements CacheBase {
   external factory MyCache();
   external num get CHECKING;
   external num get DOWNLOADING;


### PR DESCRIPTION
…constructors to abstract classes instead of concrete classes

The only exception to this is when the type returned by the constructor is a class and not an interface/type literal. In that case we can safely make the emitted class concrete.