### PR TITLE
Fixed bugs that occured when transpiling files in other directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@
 const main = require('./build/lib/main.js');
 
 var args = require('minimist')(process.argv.slice(2), {
-  base: 'string',
+  string: ['base-path'],
   boolean: [
     'semantic-diagnostics', 'generate-html', 'rename-conflicting-types', 'explicit-static',
     'trust-js-types'
   ],
+  default: {'base-path': ''},
   alias: {
     'base-path': 'basePath',
     'semantic-diagnostics': 'semanticDiagnostics',

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -443,25 +443,26 @@ export class TranspilerBase {
   }
 
   /**
-   * Return resolved named possibly including a prefix for the identifier.
+   * Return resolved name possibly including a prefix for the identifier.
    */
   resolveImportForSourceFile(sourceFile: ts.SourceFile, context: ts.SourceFile, identifier: string):
       string {
-    if (sourceFile === context) return identifier;
+    if (sourceFile === context) {
+      return identifier;
+    }
     if (sourceFile.hasNoDefaultLib) {
       // We don't want to emit imports to default lib libraries as we replace with Dart equivalents
       // such as dart:html, etc.
       return identifier;
     }
-    let relativePath = path.relative(path.dirname(context.fileName), sourceFile.fileName);
-    // TODO(jacobr): actually handle imports in different directories. We assume for now that all
-    // files in a library will be output to a single directory for codegen simplicity.
-    let parts = this.getDartFileName(relativePath).split('/');
-    let fileName = parts[parts.length - 1];
-    let identifierParts = identifier.split('.');
+    const relativePath = path.relative(path.dirname(context.fileName), sourceFile.fileName);
+    const fileName = this.getDartFileName(relativePath);
+    const identifierParts = identifier.split('.');
     identifier = identifierParts[identifierParts.length - 1];
-    let summary = this.addImport(this.transpiler.getDartFileName(fileName), identifier);
-    if (summary.asPrefix) return summary.asPrefix + '.' + identifier;
+    const summary = this.addImport(this.transpiler.getDartFileName(fileName), identifier);
+    if (summary.asPrefix) {
+      return summary.asPrefix + '.' + identifier;
+    }
     return identifier;
   }
 

--- a/lib/dart_libraries_for_browser_types.ts
+++ b/lib/dart_libraries_for_browser_types.ts
@@ -974,7 +974,7 @@ const STDLIB_TYPE_REPLACEMENTS = new Map(Object.entries({
 }));
 
 export const TS_TO_DART_TYPENAMES = new Map(Object.entries({
-  'typescript/lib/lib.es5': STDLIB_TYPE_REPLACEMENTS,
-  'typescript/lib/lib.es6': STDLIB_TYPE_REPLACEMENTS,
-  'typescript/lib/lib.dom': STDLIB_TYPE_REPLACEMENTS
+  'lib.es5': STDLIB_TYPE_REPLACEMENTS,
+  'lib.es6': STDLIB_TYPE_REPLACEMENTS,
+  'lib.dom': STDLIB_TYPE_REPLACEMENTS
 }));

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -460,7 +460,7 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
         const moduleDecl = <ts.ModuleDeclaration>node;
         const moduleName = base.getModuleName(moduleDecl);
         const moduleBlock = base.getModuleBlock(moduleDecl);
-        if (moduleName.slice(0, 2) === '..') {
+        if (moduleName.startsWith('..')) {
           this.emit(
               '\n// Library augmentation not allowed by Dart. Ignoring augmentation of ' +
               moduleDecl.name.text + '\n');

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -137,7 +137,7 @@ export class Transpiler {
     }
     fileNames = fileNames.map((name: string) => {
       const normalizedName = this.normalizeSlashes(name);
-      if (normalizedName.slice(0, 2) === './') {
+      if (normalizedName.startsWith('./')) {
         // The fileName property of SourceFiles omits ./ for files in the current directory
         return normalizedName.substring(2);
       }

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -182,7 +182,10 @@ external List<String> /*ReadonlyArray<String>*/ f();`);
 
   describe('error detection', () => {
     it('supports imports', () => {
-      expectWithTypes(`import {X} from "other";\nlet x:X;`).to.equal(`import "other.dart" show X;
+      expectWithTypes(`
+import {X} from "other";
+declare let x:X;
+`).to.equal(`import "../../other.dart" show X;
 
 @JS()
 external X get x;

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -182,6 +182,10 @@ external List<String> /*ReadonlyArray<String>*/ f();`);
 
   describe('error detection', () => {
     it('supports imports', () => {
+      // In all tests, the main code has a fake location of FAKE_MAIN, which is declared
+      // to be '/demo/some/main.ts' within test_support.ts. At the top of this file, the 'other'
+      // module is declared to have a fake path of '/other.ts'. So, the correct import path for the
+      // other module is '../../other.dart'
       expectWithTypes(`
 import {X} from "other";
 declare let x:X;


### PR DESCRIPTION
- The paths for library files weren't being resolved properly when they started with ../ or ./ so TS names weren't being converted to Dart properly (ex. Array and List)
- Files weren't being transpiled if their paths began with ./ because SourceFile.fileName strips leading ./
- The generator was already writing files to subdirectories but was still generating imports as if all files were being output to the same directory