### PR TITLE
Regenerated Program and TypeChecker after normalizing source files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Dart interop facade file is written to stdout.
 #### Flags
 `--destination=<destination-dir>`: Output generated code to destination-dir.<br>
 `--base-path=<input d.ts file directory>`: Specify the directory that contains the input d.ts files.<br>
+`--skip-formatting`: Skips running dart-format on the output. This is useful for large files (like dom.d.ts) since the node package version of dart-format is significantly slower than the version in the SDK.<br>
 `--generate-html`: Generate facades for dart:html types rather than importing them.<br>
 `--rename-conflicting-types`: Rename types to avoid conflicts in cases where a variable and a type have the exact same name, but it is not clear if they are related or not.<br>
 `--explicit-static`: Disables default assumption that properties declared on the anonymous types of top level variable declarations are static.<br>

--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ Generates `package:js` JavaScript interop facades for arbitrary TypeScript libra
 ## Usage
 
 ### Basic
-`dart_js_facade_gen <input d.ts file>`<br/>
+`dart_js_facade_gen <input d.ts file>`<br>
 Dart interop facade file is written to stdout.
 
 ### Advanced
 `dart_js_facade_gen --destination=<destination-dir> --base-path=<input d.ts file directory> <input d.ts file> <input d.ts file> ...`
 
 #### Flags
-`--destination=<destination-dir>`: output generated code to destination-dir<br/>
-`--base-path=<input d.ts file directory>`: specify the directory that contains the input d.ts files<br/>
-`--generate-html`: generate facades for dart:html types rather than importing them<br/>
-`--rename-conflicting-types`: rename types to avoid conflicts in cases where a variable and a type have the exact same name, but it is not clear if they are related or not.
-`--explicit-static`: disables default assumption that properties declared on the anonymous types of top level variable declarations are static
+`--destination=<destination-dir>`: Output generated code to destination-dir.<br>
+`--base-path=<input d.ts file directory>`: Specify the directory that contains the input d.ts files.<br>
+`--generate-html`: Generate facades for dart:html types rather than importing them.<br>
+`--rename-conflicting-types`: Rename types to avoid conflicts in cases where a variable and a type have the exact same name, but it is not clear if they are related or not.<br>
+`--explicit-static`: Disables default assumption that properties declared on the anonymous types of top level variable declarations are static.<br>
 `--trust-js-types`: Emits @anonymous tags on classes that have neither constructors nor static members. This prevents the Dart Dev Compiler from checking whether or not objects are truly instances of those classes. This flag should be used if the input JS/TS library has structural types, or is otherwise claiming that types match in cases where the correct JS prototype is not there for DDC to check against.
 
 ### Example

--- a/index.js
+++ b/index.js
@@ -5,13 +5,14 @@ const main = require('./build/lib/main.js');
 var args = require('minimist')(process.argv.slice(2), {
   string: ['base-path'],
   boolean: [
-    'semantic-diagnostics', 'generate-html', 'rename-conflicting-types', 'explicit-static',
-    'trust-js-types'
+    'semantic-diagnostics', 'skip-formatting', 'generate-html', 'rename-conflicting-types',
+    'explicit-static', 'trust-js-types'
   ],
   default: {'base-path': ''},
   alias: {
     'base-path': 'basePath',
     'semantic-diagnostics': 'semanticDiagnostics',
+    'skip-formatting': 'skipFormatting',
     'generate-html': 'generateHTML',
     'rename-conflicting-types': 'renameConflictingTypes',
     'explicit-static': 'explicitStatic',

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -471,22 +471,6 @@ export class TranspilerBase {
     this.transpiler.reportError(n, message);
   }
 
-  /**
-   * Prevents this node from being visited.
-   */
-  suppressNode(n: ts.Node) {
-    const emptyNode = ts.createNode(ts.SyntaxKind.EmptyStatement);
-    copyLocation(n, emptyNode);
-    this.replaceNode(n, emptyNode);
-  }
-
-  /**
-   * Effectively replaces original with replacement in the AST.
-   */
-  replaceNode(original: ts.Node, replacement: ts.Node) {
-    this.transpiler.nodeSubstitutions.set(original, replacement);
-  }
-
   visitNode(n: ts.Node): boolean {
     throw new Error('not implemented');
   }

--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -616,26 +616,6 @@ export class FacadeConverter extends base.TranspilerBase {
     }
   }
 
-  replaceNode(original: ts.Node, replacement: ts.Node) {
-    if (ts.isVariableDeclaration(original) &&
-        (ts.isInterfaceDeclaration(replacement) || ts.isClassDeclaration(replacement))) {
-      // Handle the speical case in mergeVariablesIntoClasses where we upgrade variable declarations
-      // to interfaces or classes.
-      const symbol = this.tc.getSymbolAtLocation(original.name);
-      symbol.declarations = symbol.getDeclarations().map((declaration: ts.Declaration) => {
-        // TODO(derekx): Changing the declarations of a symbol like this is a hack. It would be
-        // cleaner and safer to generate a new Program and TypeChecker after performing
-        // gatherClasses and mergeVariablesIntoClasses.
-        if (declaration === original) {
-          return replacement;
-        }
-        return declaration;
-      });
-    }
-
-    super.replaceNode(original, replacement);
-  }
-
   getSymbolAtLocation(identifier: ts.EntityName) {
     let symbol = this.tc.getSymbolAtLocation(identifier);
     while (symbol && symbol.flags & ts.SymbolFlags.Alias) symbol = this.tc.getAliasedSymbol(symbol);

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -385,6 +385,9 @@ export class Transpiler {
       result += output.getResult();
     }
 
+    if (this.options.skipFormatting) {
+      return result;
+    }
     return this.formatCode(result, sourceFile);
   }
 

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -1,15 +1,15 @@
 import {expectTranslate, FAKE_MAIN} from './test_support';
 
-function getSources(str: string): {[k: string]: string} {
-  let srcs: {[k: string]: string} = {
+function getSources(str: string): Map<string, string> {
+  const srcs: Map<string, string> = new Map(Object.entries({
     'other.ts': `
         export class X {
           map(x: number): string { return String(x); }
           static get(m: any, k: string): number { return m[k]; }
         }
     `,
-  };
-  srcs[FAKE_MAIN] = str;
+  }));
+  srcs.set(FAKE_MAIN, str);
   return srcs;
 }
 

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -77,8 +77,9 @@ describe('module name', () => {
   });
   it('adds module name', () => {
     let results = translateSources(
-        {'/a/b/c.ts': 'var x;'}, {failFast: true, moduleName: 'sample_module', basePath: '/a'});
-    chai.expect(results['/a/b/c.ts']).to.equal(`@JS("sample_module")
+        new Map(Object.entries({'/a/b/c.ts': 'var x;'})),
+        {failFast: true, moduleName: 'sample_module', basePath: '/a'});
+    chai.expect(results.get('/a/b/c.ts')).to.equal(`@JS("sample_module")
 library b.c;
 
 import "package:js/js.dart";


### PR DESCRIPTION
This allows the FacadeConverter to have access to the correct type and value declarations after we have merged variables with classes.

Refactored test_support so that it shares more code with main, and performs the same normalization of source files.